### PR TITLE
Fix typo in description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,7 +46,7 @@
 		<dc:description id="description">Two young writers experience romance and adventure in Lord Emsworth’s Blandings Castle.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;i&gt;Something New&lt;/i&gt; is the first novel of what became known as the “Blandings Castle Saga” by P. G. Wodehouse and was published in the United States in 1915. Two Americans, Ashe Marson and Joan Valentine, endeavor to retrieve a scarab pilfered from an American millionaire by the absent-minded Lord Emsworth. Marson and Valentine soon find themselves impersonating servants while evading the Efficient Baxter.&lt;/p&gt;
-			&lt;p&gt;The story was originally serialized in the &lt;i&gt;Saturday Evening Post&lt;/i&gt; as &lt;i&gt;Something Fresh&lt;/i&gt; in 1915. It introduced what would become the recurring characters or Blandings Castle: Lord Emsworth, Freddie Threepwood, Rupert Baxter, and Sebastian Beach.&lt;/p&gt;
+			&lt;p&gt;The story was originally serialized in the &lt;i&gt;Saturday Evening Post&lt;/i&gt; as &lt;i&gt;Something Fresh&lt;/i&gt; in 1915. It introduced who would become the recurring characters of Blandings Castle: Lord Emsworth, Freddie Threepwood, Rupert Baxter, and Sebastian Beach.&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/2042</dc:source>


### PR DESCRIPTION
* “characters or Blandings Castle” → “characters <ins>of</ins> Blandings Castle”
* use “who” instead of “what” when referring to said characters